### PR TITLE
Fix calc

### DIFF
--- a/snyk.go
+++ b/snyk.go
@@ -9,7 +9,6 @@ import (
 	"net/http"
 	"net/url"
 	"os"
-	"strings"
 )
 
 var (
@@ -117,10 +116,15 @@ func vulnerabilitiesFound(projects []interface{}, name string, projectID string)
 	for _, project := range projects {
 		project := project.(map[string]interface{})
 		// fmt.Println(project["name"], name)
-		if strings.HasPrefix(project["name"].(string), name) || project["id"].(string) == projectID {
-			totalIssues = countVulnerabilities(project)
+		if project["name"].(string) == name {
+			totalIssues = totalIssues + countVulnerabilities(project)
 			valid = true
-			break
+			// continue
+		}
+		if project["id"].(string) == projectID {
+			totalIssues = totalIssues + countVulnerabilities(project)
+			valid = true
+			// continue
 		}
 	}
 	return totalIssues, valid

--- a/snyk.go
+++ b/snyk.go
@@ -180,7 +180,7 @@ func writeBadge(w http.ResponseWriter, badgeURL string) {
 }
 
 func Handler(w http.ResponseWriter, r *http.Request) {
-	log.Println("url path: ", r.URL.Path)
+	log.Println("url path: ", r.URL.Path, r.URL.RawQuery)
 	values, err := url.ParseQuery(r.URL.RawQuery)
 	if err != nil {
 		// if fails to parse URL parameters, just answer it quickly

--- a/snyk_test.go
+++ b/snyk_test.go
@@ -298,6 +298,14 @@ func TestHandler(t *testing.T) {
 	handler5.ServeHTTP(rr5, req5)
 	assert.Equal(t, http.StatusOK, rr5.Code)
 
+	req6, err6 := http.NewRequest("GET", "/api/badges?org=TestOrg&name=repositoryOne&id=e48bd952-7a33-0ad8-fec5-e5d644cb9051,01a88ebb-ee9d-0650-ba1d-c5a93668b36f", nil)
+	assert.NoError(t, err6)
+	rr6 := httptest.NewRecorder()
+	handler6 := http.HandlerFunc(Handler)
+
+	handler6.ServeHTTP(rr6, req6)
+	assert.Equal(t, http.StatusOK, rr6.Code)
+
 }
 
 func TestHandlerErrors(t *testing.T) {


### PR DESCRIPTION
# Changed
- fix calculation loop
- add workaround to fix azure function write proxy from `org=Org&id=a1&id=b1` to `org=Org&id=a1,b1` replacing `,` with `&id=`. 